### PR TITLE
Configurable db engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Open .env with a text editor and adapt the environment variables with your
 configuration:
 
 * `MAILMAN_SECRET` a long unique random string to sign the JWT token
+* `MAILMAN_DB_ENGINE` the engine used by mailman. defaults to maria if no value given.
 * `MAILMAN_DB_USER` the `vmail` database user
 * `MAILMAN_DB_PASSWORD` the password for the `vmail` database user
 * `MAILMAN_DB_DATABASE` the `vmail` database

--- a/src/db.js
+++ b/src/db.js
@@ -1,7 +1,7 @@
 import knex from "knex";
 
 const db = knex({
-  client: "maria",
+  client: process.env.MAILMAN_DB_ENGINE || "maria",
   connection: {
     host: process.env.MAILMAN_DB_HOST || "127.0.0.1",
     user: process.env.MAILMAN_DB_USER,

--- a/src/db.js
+++ b/src/db.js
@@ -6,7 +6,7 @@ const db = knex({
     host: process.env.MAILMAN_DB_HOST || "127.0.0.1",
     user: process.env.MAILMAN_DB_USER,
     password: process.env.MAILMAN_DB_PASSWORD,
-    db: process.env.MAILMAN_DB_DATABASE
+    database: process.env.MAILMAN_DB_DATABASE
   }
 });
 


### PR DESCRIPTION
Hi,
I used your frontend for my mailserver a long time.
But for switching from mysql to postgres as installed database there were some modifications needed.
As Knex is a generic SQL builder the frontend works like a charm with the following change(s).

The parameter change is done due a change in knex, which you already did on your improvements branch.
Without the app looked for a database "mailman".

As i am not able to build & run your improvement branch i can just test it for the master.
Feel free to include the change.

I refused to push pg as dependency, as you (and also the tutorial for the configuration) mainly supports mysql/mariadb

To use postgresql install pg as dependency, set MAILMAN_DB_ENGINE to pg and restart the service.